### PR TITLE
fix: scoping bug which ignored custom command inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ import 'cypress-codegen';
 
 Check out this project's `cypress` directory for a generic example!
 
+## Custom Command Chaining
+
+If you want to create custom commands that are meant to be scoped to a previous command's result, put `Scoped` at the
+end of your custom command function name (e.g. `myCustomCommandScoped`). This will set the `prevSubject` option when
+adding the custom command. See the [Cypress docs](https://docs.cypress.io/api/cypress-api/custom-commands#Arguments)
+for more details.
+
 ## Configuration
 
 ### Javascript

--- a/cypress/commands/example.ts
+++ b/cypress/commands/example.ts
@@ -13,10 +13,12 @@ limitations under the License.
 
 export function functionExample(input: string) {
   cy.log('Here is a custom command!');
+  cy.contains(input);
 }
 
 export const arrowFunctionExample = (input: string) => {
-  cy.log('Here is a custom command from an arrow function!').log(input);
+  cy.log('Here is a custom command from an arrow function!');
+  cy.contains(input);
 };
 
 declare global {

--- a/cypress/commands/nested/nested-example.ts
+++ b/cypress/commands/nested/nested-example.ts
@@ -12,7 +12,8 @@ limitations under the License.
 */
 
 export const nestedExample = (input: string) => {
-  cy.log('Here is a custom command in a nested directory!').log(input);
+  cy.log('Here is a custom command in a nested directory!');
+  cy.contains(input);
 };
 
 declare global {

--- a/cypress/e2e/example.cy.ts
+++ b/cypress/e2e/example.cy.ts
@@ -11,20 +11,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const expectedText = 'Kitchen Sink';
+
 describe('Example Test', () => {
+  before(() => {
+    cy.visit('https://example.cypress.io/');
+  });
+
   it('should dynamically import custom commands from functions', () => {
-    cy.functionExample('Functions work!');
+    cy.functionExample(expectedText);
   });
 
   it('should dynamically import custom commands from arrow functions', () => {
-    cy.arrowFunctionExample('Arrow functions work!');
+    cy.arrowFunctionExample(expectedText);
   });
 
   it('should dynamically import nested custom commands', () => {
-    cy.nestedExample('Nested custom commands work!');
+    cy.nestedExample(expectedText);
   });
 
   it('should chain custom commands', () => {
-    cy.log('Custom commands can chain, too!').functionExample('1').arrowFunctionExample('2').nestedExample('3');
+    cy.log(expectedText).functionExample(expectedText).arrowFunctionExample(expectedText).nestedExample(expectedText);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Chainable = Cypress.Chainable;
 import { sep } from 'path';
 
 before('Import Custom Commands', () => {
@@ -20,8 +19,13 @@ before('Import Custom Commands', () => {
       // This relative file path is extremely particular and for some unknown reason must be exactly this.
       const customCommandObject = require(`../../../cypress/commands/${filePath.replace(`cypress${sep}commands${sep}`, '')}`);
       const methodNames = Object.keys(customCommandObject);
-      methodNames.forEach(methodName => {
-        Cypress.Commands.add(methodName as keyof Chainable, { prevSubject: 'optional' }, customCommandObject[methodName]);
+      methodNames.forEach((methodName: keyof Cypress.Chainable) => {
+        const method = customCommandObject[methodName];
+        if (methodName.endsWith('Scoped')) {
+          Cypress.Commands.add(methodName, { prevSubject: 'element' }, method);
+        } else {
+          Cypress.Commands.add(methodName, method);
+        }
       });
     });
   });


### PR DESCRIPTION
### :pencil: Description

Fixes a bug where the custom command inputs were not getting correctly passed due to `prevSubject` always being included in `Cypress.Command.add()`.