### PR TITLE
fix: prettify output of generated types

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "printWidth": 140,
+  "printWidth": 100,
   "useTabs": false,
   "singleQuote": true,
   "trailingComma": "none",

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ end of your custom command function name (e.g. `myCustomCommandScoped`). This wi
 adding the custom command. See the [Cypress docs](https://docs.cypress.io/api/cypress-api/custom-commands#Arguments)
 for more details.
 
+## Code Styling
+
+`cypress-codegen` will attempt to read your `prettierrc` config by default.
+However, you may pass a config override in the cypress.config.ts invocation:
+```ts
+setupNodeEvents(on, config) {
+    cypressCodegen(on, config, prettierConfigOverride);
+    return config;
+}
+```
+
 ## Configuration
 
 ### Javascript

--- a/cypress/commands/example.ts
+++ b/cypress/commands/example.ts
@@ -12,7 +12,9 @@ limitations under the License.
 */
 
 export function functionExample(input: string) {
-  cy.log('Here is a custom command!').log('And it preserves my code styling!');
+  cy.log('Here is a custom command!')
+    .log('And it preserves my code styling')
+    .log('When I chain commands on new lines!');
   cy.contains(input);
 }
 

--- a/cypress/commands/example.ts
+++ b/cypress/commands/example.ts
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 export function functionExample(input: string) {
-  cy.log('Here is a custom command!');
+  cy.log('Here is a custom command!').log('And it preserves my code styling!');
   cy.contains(input);
 }
 

--- a/cypress/e2e/e2e-example.cy.ts
+++ b/cypress/e2e/e2e-example.cy.ts
@@ -31,6 +31,9 @@ describe('Example Test', () => {
   });
 
   it('should chain custom commands', () => {
-    cy.log(expectedText).functionExample(expectedText).arrowFunctionExample(expectedText).nestedExample(expectedText);
+    cy.log(expectedText)
+      .functionExample(expectedText)
+      .arrowFunctionExample(expectedText)
+      .nestedExample(expectedText);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@babel/generator": "7.18.2",
         "@babel/parser": "7.18.5",
         "@babel/types": "7.18.4",
-        "glob": "8.0.3"
+        "glob": "8.0.3",
+        "prettier": "2.7.1"
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.1",
@@ -30,7 +31,6 @@
         "eslint-plugin-typescript": "0.14.0",
         "husky": "8.0.1",
         "jest": "28.1.1",
-        "prettier": "2.7.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-scripts": "5.0.1",
@@ -17941,7 +17941,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -35985,8 +35984,7 @@
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "@babel/generator": "7.18.2",
     "@babel/parser": "7.18.5",
     "@babel/types": "7.18.4",
-    "glob": "8.0.3"
+    "glob": "8.0.3",
+    "prettier": "2.7.1"
   },
   "peerDependencies": {
     "cypress": ">=10"
@@ -29,7 +30,6 @@
     "eslint-plugin-typescript": "0.14.0",
     "husky": "8.0.1",
     "jest": "28.1.1",
-    "prettier": "2.7.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-scripts": "5.0.1",

--- a/src/generate-types-from-abstract-syntax-tree.ts
+++ b/src/generate-types-from-abstract-syntax-tree.ts
@@ -33,12 +33,16 @@ export const generateTypesFromAbstractSyntaxTree = (filePath: string, prettierCo
   const currentNodes = ast.program.body;
   const customCommands = currentNodes
     .filter(
-      node => t.isExportNamedDeclaration(node) && (t.isFunctionDeclaration(node.declaration) || t.isVariableDeclaration(node.declaration))
+      node =>
+        t.isExportNamedDeclaration(node) &&
+        (t.isFunctionDeclaration(node.declaration) || t.isVariableDeclaration(node.declaration))
     )
     .map((node: ExportNamedDeclaration) => {
       const declaration = node.declaration as FunctionDeclaration | VariableDeclaration;
       const isVariableDeclaration = t.isVariableDeclaration(declaration);
-      const functionIdentifier = isVariableDeclaration ? (declaration.declarations[0].id as Identifier) : declaration.id;
+      const functionIdentifier = isVariableDeclaration
+        ? (declaration.declarations[0].id as Identifier)
+        : declaration.id;
       const functionParameters = isVariableDeclaration
         ? (declaration.declarations[0].init as FunctionExpression).params
         : declaration.params;
@@ -58,8 +62,9 @@ export const generateTypesFromAbstractSyntaxTree = (filePath: string, prettierCo
   const interfaceExists = t.isTSModuleDeclaration(lastNode) && lastNode.global && lastNode.declare;
   const newNodes = interfaceExists ? currentNodes.slice(0, currentNodes.length - 1) : currentNodes;
   const { code: existingCode } = generate(t.program(newNodes), { retainLines: true });
+  const formattedExistingCode = format(existingCode, { parser: 'babel', ...prettierConfig });
   const { code: newCode } = generate(t.program(newInterface));
-  return `${format(existingCode, { parser: 'babel', ...prettierConfig })}\n${newCode}\n`;
+  return `${formattedExistingCode}\n${newCode}\n`;
 };
 
 interface CustomCommand {
@@ -86,7 +91,12 @@ const generateInterface = (customCommands: CustomCommand[]): Statement[] => {
             null,
             t.tsInterfaceBody(
               customCommands.map(({ functionIdentifier, parameters }) =>
-                t.tsMethodSignature(functionIdentifier, null, parameters, t.tsTypeAnnotation(t.tsTypeReference(t.identifier('Chainable'))))
+                t.tsMethodSignature(
+                  functionIdentifier,
+                  null,
+                  parameters,
+                  t.tsTypeAnnotation(t.tsTypeReference(t.identifier('Chainable')))
+                )
               )
             )
           )

--- a/src/generate-types-from-abstract-syntax-tree.ts
+++ b/src/generate-types-from-abstract-syntax-tree.ts
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import { parse } from '@babel/parser';
-import { format, resolveConfig } from 'prettier';
 import type {
   AssignmentPattern,
   ExportNamedDeclaration,
@@ -26,8 +25,9 @@ import * as t from '@babel/types';
 import generate from '@babel/generator';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { format, Options } from 'prettier';
 
-export const generateTypesFromAbstractSyntaxTree = async (filePath: string) => {
+export const generateTypesFromAbstractSyntaxTree = (filePath: string, prettierConfig?: Options) => {
   const contents = readFileSync(resolve(filePath)).toString();
   const ast = parse(contents, { sourceType: 'module', plugins: ['typescript'] });
   const currentNodes = ast.program.body;
@@ -59,8 +59,7 @@ export const generateTypesFromAbstractSyntaxTree = async (filePath: string) => {
   const newNodes = interfaceExists ? currentNodes.slice(0, currentNodes.length - 1) : currentNodes;
   const { code: existingCode } = generate(t.program(newNodes), { retainLines: true });
   const { code: newCode } = generate(t.program(newInterface));
-  const prettierOptions = await resolveConfig(process.cwd());
-  return `${format(existingCode, prettierOptions)}\n\n${newCode}\n`;
+  return `${format(existingCode, { parser: 'babel', ...prettierConfig })}\n${newCode}\n`;
 };
 
 interface CustomCommand {

--- a/src/generate-types-from-abstract-syntax-tree.ts
+++ b/src/generate-types-from-abstract-syntax-tree.ts
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import { parse } from '@babel/parser';
+import { format, resolveConfig } from 'prettier';
 import type {
   AssignmentPattern,
   ExportNamedDeclaration,
@@ -26,7 +27,7 @@ import generate from '@babel/generator';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-export const generateTypesFromAbstractSyntaxTree = (filePath: string) => {
+export const generateTypesFromAbstractSyntaxTree = async (filePath: string) => {
   const contents = readFileSync(resolve(filePath)).toString();
   const ast = parse(contents, { sourceType: 'module', plugins: ['typescript'] });
   const currentNodes = ast.program.body;
@@ -58,7 +59,8 @@ export const generateTypesFromAbstractSyntaxTree = (filePath: string) => {
   const newNodes = interfaceExists ? currentNodes.slice(0, currentNodes.length - 1) : currentNodes;
   const { code: existingCode } = generate(t.program(newNodes), { retainLines: true });
   const { code: newCode } = generate(t.program(newInterface));
-  return `${existingCode}\n\n${newCode}\n`;
+  const prettierOptions = await resolveConfig(process.cwd());
+  return `${format(existingCode, prettierOptions)}\n\n${newCode}\n`;
 };
 
 interface CustomCommand {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,19 +12,24 @@ limitations under the License.
 */
 
 before('Import Custom Commands', () => {
-  cy.task('importCustomCommands').then(({ filePaths, commandsDirectory }: { filePaths: string[]; commandsDirectory: string }) => {
-    filePaths.forEach(filePath => {
-      // This relative file path is extremely particular and for some unknown reason must be exactly this.
-      const customCommandObject = require(`../../../cypress/commands/${filePath.replace(commandsDirectory, '')}`);
-      const methodNames = Object.keys(customCommandObject);
-      methodNames.forEach((methodName: keyof Cypress.Chainable) => {
-        const method = customCommandObject[methodName];
-        if (methodName.endsWith('Scoped')) {
-          Cypress.Commands.add(methodName, { prevSubject: 'element' }, method);
-        } else {
-          Cypress.Commands.add(methodName, method);
-        }
+  cy.task('importCustomCommands').then(
+    ({ filePaths, commandsDirectory }: { filePaths: string[]; commandsDirectory: string }) => {
+      filePaths.forEach(filePath => {
+        // This relative file path is extremely particular and for some unknown reason must be exactly this.
+        const customCommandObject = require(`../../../cypress/commands/${filePath.replace(
+          commandsDirectory,
+          ''
+        )}`);
+        const methodNames = Object.keys(customCommandObject);
+        methodNames.forEach((methodName: keyof Cypress.Chainable) => {
+          const method = customCommandObject[methodName];
+          if (methodName.endsWith('Scoped')) {
+            Cypress.Commands.add(methodName, { prevSubject: 'element' }, method);
+          } else {
+            Cypress.Commands.add(methodName, method);
+          }
+        });
       });
-    });
-  });
+    }
+  );
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -23,8 +23,8 @@ export const cypressCodegen: Cypress.PluginConfig = (on: Cypress.PluginEvents, c
     on('before:browser:launch', (browser, launchOptions) => {
       const filePaths = sync(`${COMMANDS_DIRECTORY}/**/*`, { nodir: true });
 
-      filePaths.forEach(filePath => {
-        const fileContentsWithTypes = generateTypesFromAbstractSyntaxTree(filePath);
+      filePaths.forEach(async filePath => {
+        const fileContentsWithTypes = await generateTypesFromAbstractSyntaxTree(filePath);
 
         writeFileSync(resolve(filePath), fileContentsWithTypes);
       });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,16 +15,21 @@ import { sync } from 'glob';
 import { generateTypesFromAbstractSyntaxTree } from './generate-types-from-abstract-syntax-tree';
 import { writeFileSync } from 'fs';
 import { resolve, sep } from 'path';
+import { Options as PrettierConfig } from 'prettier';
 
 export const COMMANDS_DIRECTORY = 'cypress/commands';
 
-export const cypressCodegen: Cypress.PluginConfig = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
+export const cypressCodegen: Cypress.PluginConfig = (
+  on: Cypress.PluginEvents,
+  config: Cypress.PluginConfigOptions,
+  prettierConfig?: PrettierConfig
+) => {
   if (config.env.CODEGEN !== false) {
     on('before:browser:launch', (browser, launchOptions) => {
       const filePaths = sync(`${COMMANDS_DIRECTORY}/**/*`, { nodir: true });
 
-      filePaths.forEach(async filePath => {
-        const fileContentsWithTypes = await generateTypesFromAbstractSyntaxTree(filePath);
+      filePaths.forEach(filePath => {
+        const fileContentsWithTypes = generateTypesFromAbstractSyntaxTree(filePath, prettierConfig);
 
         writeFileSync(resolve(filePath), fileContentsWithTypes);
       });

--- a/test/generate-types-from-abstract-syntax-tree.test.ts
+++ b/test/generate-types-from-abstract-syntax-tree.test.ts
@@ -19,6 +19,10 @@ import { readFileSync } from 'fs';
 jest.mock('fs');
 
 const filePath = 'filePath';
+const prettierConfig = {
+  singleQuote: true,
+  printWidth: 140
+};
 
 describe('generateTypesFromAbstractSyntaxTree', () => {
   it('should generate types when types do not exist', async () => {
@@ -44,7 +48,7 @@ export const arrowFunctionExample = (input1: string) => {
   cy.log('Here is a custom command from an arrow function!').log(input);
 };
 `);
-    const result = generateTypesFromAbstractSyntaxTree(filePath);
+    const result = generateTypesFromAbstractSyntaxTree(filePath, prettierConfig);
     expect(result).toEqual(`// some comment
 
 export function functionExampleOneInput(input1: string) {
@@ -113,11 +117,90 @@ declare global {
   }
 }
 `);
-    const result = generateTypesFromAbstractSyntaxTree(filePath);
+    const result = generateTypesFromAbstractSyntaxTree(filePath, prettierConfig);
     expect(result).toEqual(`// some comment
 
 export function functionExampleOneInput(input1: string) {
   cy.log('Here is a custom command!');
+}
+
+export function functionExampleTwoInputs(input1: string, input2: number) {
+  cy.log('Here is a custom command!');
+}
+
+export function functionExampleOptionalInput(input1: string, input2?: number) {
+  cy.log('Here is a custom command!');
+}
+
+export function functionExampleWithInitializer(input1: string, input2: number = 0) {
+  cy.log('Here is a custom command!');
+}
+
+export const arrowFunctionExample = (input1: string) => {
+  cy.log('Here is a custom command from an arrow function!').log(input);
+};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      functionExampleOneInput(input1: string): Chainable;
+      functionExampleTwoInputs(input1: string, input2: number): Chainable;
+      functionExampleOptionalInput(input1: string, input2?: number): Chainable;
+      functionExampleWithInitializer(input1: string, input2?: number): Chainable;
+      arrowFunctionExample(input1: string): Chainable;
+    }
+  }
+}
+`);
+  });
+
+  it('should preserve formatting', async () => {
+    (readFileSync as jest.Mock).mockReturnValue(`// some comment
+
+export function functionExampleOneInput(input1: string) {
+  cy.log('Here is a custom command!')
+    .log('With custom formatting')
+    .log('With custom formatting')
+    .log('With custom formatting')
+    .log('With custom formatting')
+    .log('With custom formatting');
+}
+
+export function functionExampleTwoInputs(input1: string, input2: number) {
+  cy.log('Here is a custom command!');
+}
+
+export function functionExampleOptionalInput(input1: string, input2?: number) {
+  cy.log('Here is a custom command!');
+}
+
+export function functionExampleWithInitializer(input1: string, input2: number = 0) {
+  cy.log('Here is a custom command!');
+}
+
+export const arrowFunctionExample = (input1: string) => {
+  cy.log('Here is a custom command from an arrow function!').log(input);
+};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      something(input1: string): Chainable;
+      somethingElse(input1: string): Chainable;
+    }
+  }
+}
+`);
+    const result = generateTypesFromAbstractSyntaxTree(filePath, prettierConfig);
+    expect(result).toEqual(`// some comment
+
+export function functionExampleOneInput(input1: string) {
+  cy.log('Here is a custom command!')
+    .log('With custom formatting')
+    .log('With custom formatting')
+    .log('With custom formatting')
+    .log('With custom formatting')
+    .log('With custom formatting');
 }
 
 export function functionExampleTwoInputs(input1: string, input2: number) {

--- a/test/generate-types-from-abstract-syntax-tree.test.ts
+++ b/test/generate-types-from-abstract-syntax-tree.test.ts
@@ -21,7 +21,7 @@ jest.mock('fs');
 const filePath = 'filePath';
 const prettierConfig = {
   singleQuote: true,
-  printWidth: 140
+  printWidth: 90
 };
 
 describe('generateTypesFromAbstractSyntaxTree', () => {
@@ -160,9 +160,6 @@ declare global {
 export function functionExampleOneInput(input1: string) {
   cy.log('Here is a custom command!')
     .log('With custom formatting')
-    .log('With custom formatting')
-    .log('With custom formatting')
-    .log('With custom formatting')
     .log('With custom formatting');
 }
 
@@ -196,9 +193,6 @@ declare global {
 
 export function functionExampleOneInput(input1: string) {
   cy.log('Here is a custom command!')
-    .log('With custom formatting')
-    .log('With custom formatting')
-    .log('With custom formatting')
     .log('With custom formatting')
     .log('With custom formatting');
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/new-project/blob/master/CONTRIBUTING.md
-->

### :pencil: Description

Applies prettier to the output of the command file code. It will now read the project's prettier config by default, allowing for a config override as well.