### PR TITLE
feat: support project flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ setupNodeEvents(on, config) {
 
 ## Configuration
 
+### Project Flag
+
+If you are using the `--project` flag when starting Cypress, you will need to set the Cypress environment variable `PROJECT` to your project name.
+
+In cypress.config.ts:
+
+```ts
+env: {
+    PROJECT: 'my-project';
+}
+```
+
 ### Javascript
 
 The IntelliSense codegen feature is enabled by default.
@@ -100,12 +112,10 @@ You will still get the benefit of the custom commands being loaded automatically
 CYPRESS_CODEGEN=false npx cypress run
 ```
 
-or in `cypress.json`:
+or in `cypress.config.js`:
 
-```json
-{
-    "env": {
-        "CODEGEN": false
-    }
+```ts
+env: {
+    CODEGEN: false;
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,9 @@ before('Import Custom Commands', () => {
   cy.task('importCustomCommands').then(
     ({ filePaths, commandsDirectory }: { filePaths: string[]; commandsDirectory: string }) => {
       filePaths.forEach(filePath => {
+        const projectName = Cypress.env('PROJECT') ? `${Cypress.env('PROJECT')}/` : '';
         // This relative file path is extremely particular and for some unknown reason must be exactly this.
-        const customCommandObject = require(`../../../cypress/commands/${filePath.replace(
+        const customCommandObject = require(`../../../${projectName}cypress/commands/${filePath.replace(
           commandsDirectory,
           ''
         )}`);


### PR DESCRIPTION
### :pencil: Description
Adds support for projects that use the `--project` Cypress flag. Those projects will just need to set the Cypress env var `PROJECT` accordingly.

### :link: Related Issues
#18