### PR TITLE
fix: throw descriptive error for object destructuring

### DIFF
--- a/src/generate-types-from-abstract-syntax-tree.ts
+++ b/src/generate-types-from-abstract-syntax-tree.ts
@@ -92,14 +92,17 @@ const generateInterface = (customCommands: CustomCommand[]): Statement[] => {
             null,
             null,
             t.tsInterfaceBody(
-              customCommands.map(({ functionIdentifier, parameters }) =>
-                t.tsMethodSignature(
+              customCommands.map(({ functionIdentifier, parameters }) => {
+                if (parameters.some(parameter => t.isObjectPattern(parameter))) {
+                  throw new Error('Object destructuring in function parameters is not supported.');
+                }
+                return t.tsMethodSignature(
                   functionIdentifier,
                   null,
                   parameters,
                   t.tsTypeAnnotation(t.tsTypeReference(t.identifier('Chainable')))
-                )
-              )
+                );
+              })
             )
           )
         ])

--- a/test/generate-types-from-abstract-syntax-tree.test.ts
+++ b/test/generate-types-from-abstract-syntax-tree.test.ts
@@ -256,4 +256,15 @@ declare global {
 }
 `);
   });
+
+  it('should throw descriptive error for object-destructured input', async () => {
+    (readFileSync as jest.Mock).mockReturnValue(`
+
+export const objectDestructureExample = ({ input1, input2 }: { input1: string; input2: string }) => {
+  cy.log(input1);
+  cy.log(input2);
+};
+`);
+    expect(() => generateTypesFromAbstractSyntaxTree(filePath, prettierConfig)).toThrowError();
+  });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/new-project/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Object destructuring is not natively supported by `@babel/types` so it won't be supported for custom command parameters at this time. This PR adds a descriptive error in this case.

### :link: Related Issues
#26