### PR TITLE
fix: export plugin from top level

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@
 .idea
 .github
 cypress
-src
 test
 *.json
 *.yaml

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Model your Cypress project exactly like [the one in this repository](https://git
 1. Add the required plugin code to `cypress.config.ts` like so:
 
 ```ts
-import { cypressCodegen } from 'cypress-codegen/dist/plugin';
+import { cypressCodegen } from 'cypress-codegen';
 import { defineConfig } from 'cypress';
 
 export default defineConfig({

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Model your Cypress project exactly like [the one in this repository](https://git
 1. Add the required plugin code to `cypress.config.ts` like so:
 
 ```ts
-import { cypressCodegen } from 'cypress-codegen';
+import { cypressCodegen } from 'cypress-codegen/plugin';
 import { defineConfig } from 'cypress';
 
 export default defineConfig({

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,4 @@
-import { cypressCodegen } from 'cypress-codegen';
+import { cypressCodegen } from 'cypress-codegen/plugin';
 import { defineConfig } from 'cypress';
 
 export default defineConfig({

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,4 @@
-import { cypressCodegen } from 'cypress-codegen/dist/plugin';
+import { cypressCodegen } from 'cypress-codegen';
 import { defineConfig } from 'cypress';
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "bin": {
     "cypress-codegen": "dist/cli.js"
   },
+  "files": [
+    "dist",
+    "plugin"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ExpediaGroup/cypress-codegen.git"
@@ -48,7 +52,7 @@
     "typescript": "4.7.4"
   },
   "scripts": {
-    "build": "tsc --skipLibCheck && mkdir -p node_modules/cypress-codegen/dist && cp -r dist package.json node_modules/cypress-codegen",
+    "build": "tsc --skipLibCheck && mkdir -p node_modules/cypress-codegen/dist && cp -r dist plugin package.json node_modules/cypress-codegen",
     "cli": "ts-node src/cli.ts",
     "cypress:open": "cypress open",
     "cypress:component": "cypress run --component",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cypress-codegen/plugin",
+  "private": true,
+  "main": "../dist/plugin/index.js"
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 import * as chalk from 'chalk';
 import { program } from 'commander';
-import { codegen } from './codegen';
+import { codegen } from './plugin/codegen';
 
 console.log(chalk.yellowBright('Generating custom command types...'));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,5 @@ before('Import Custom Commands', () => {
     });
   });
 });
+
+export { cypressCodegen } from './plugin';

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,5 +44,3 @@ before('Import Custom Commands', () => {
     });
   });
 });
-
-export { cypressCodegen } from './plugin';

--- a/src/plugin/codegen.ts
+++ b/src/plugin/codegen.ts
@@ -1,5 +1,5 @@
 import { sync } from 'glob';
-import { COMMANDS_DIRECTORY } from './common';
+import { COMMANDS_DIRECTORY } from '../common';
 import { resolveConfig, Options as PrettierConfig } from 'prettier';
 import { generateTypesFromAbstractSyntaxTree } from './generate-types-from-abstract-syntax-tree';
 import { writeFileSync } from 'fs';

--- a/src/plugin/generate-types-from-abstract-syntax-tree.ts
+++ b/src/plugin/generate-types-from-abstract-syntax-tree.ts
@@ -26,7 +26,7 @@ import generate from '@babel/generator';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { format, Options } from 'prettier';
-import { isScopedMethod } from './common';
+import { isScopedMethod } from '../common';
 
 export const generateTypesFromAbstractSyntaxTree = (filePath: string, prettierConfig: Options) => {
   const contents = readFileSync(resolve(filePath)).toString();

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -14,7 +14,7 @@ limitations under the License.
 import { sync } from 'glob';
 import { sep } from 'path';
 import { Options as PrettierConfig } from 'prettier';
-import { COMMANDS_DIRECTORY } from './common';
+import { COMMANDS_DIRECTORY } from '../common';
 import { codegen } from './codegen';
 
 export type CypressCodegen = (

--- a/test/generate-types-from-abstract-syntax-tree.test.ts
+++ b/test/generate-types-from-abstract-syntax-tree.test.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { generateTypesFromAbstractSyntaxTree } from '../src/generate-types-from-abstract-syntax-tree';
+import { generateTypesFromAbstractSyntaxTree } from '../src/plugin/generate-types-from-abstract-syntax-tree';
 
 import { expect } from '@jest/globals';
 import { readFileSync } from 'fs';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "lib": ["ES2019", "DOM"],
     "jsx": "react"
   },
-  "include": ["src", "node_modules/cypress"]
+  "include": ["src", "plugin", "node_modules/cypress"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- This should allow cypress-codegen to work with `pnpm` which does not allow direct imports from `dist`.