### PR TITLE
fix: use babel-ts parser for prettier formatting

### DIFF
--- a/src/plugin/generate-types-from-abstract-syntax-tree.ts
+++ b/src/plugin/generate-types-from-abstract-syntax-tree.ts
@@ -67,7 +67,7 @@ export const generateTypesFromAbstractSyntaxTree = (filePath: string, prettierCo
   const interfaceExists = t.isTSModuleDeclaration(lastNode) && lastNode.global && lastNode.declare;
   const newNodes = interfaceExists ? currentNodes.slice(0, currentNodes.length - 1) : currentNodes;
   const { code: existingCode } = generate(t.program(newNodes), { retainLines: true });
-  const formattedExistingCode = format(existingCode, { parser: 'babel', ...prettierConfig });
+  const formattedExistingCode = format(existingCode, { parser: 'babel-ts', ...prettierConfig });
   const { code: newCode } = generate(t.program(newInterface));
   return `${formattedExistingCode}\n${newCode}\n`;
 };

--- a/test/generate-types-from-abstract-syntax-tree.test.ts
+++ b/test/generate-types-from-abstract-syntax-tree.test.ts
@@ -25,7 +25,7 @@ const prettierConfig = {
 };
 
 describe('generateTypesFromAbstractSyntaxTree', () => {
-  it('should generate types when types do not exist', async () => {
+  it('should generate types when types do not exist', () => {
     (readFileSync as jest.Mock).mockReturnValue(`// some comment
 
 export function functionExampleOneInput(input1: string) {
@@ -85,7 +85,7 @@ declare global {
 `);
   });
 
-  it('should generate types when types exist', async () => {
+  it('should generate types when types exist', () => {
     (readFileSync as jest.Mock).mockReturnValue(`// some comment
 
 export function functionExampleOneInput(input1: string) {
@@ -154,7 +154,7 @@ declare global {
 `);
   });
 
-  it('should preserve formatting', async () => {
+  it('should preserve formatting', () => {
     (readFileSync as jest.Mock).mockReturnValue(`// some comment
 
 export function functionExampleOneInput(input1: string) {
@@ -227,7 +227,7 @@ declare global {
 `);
   });
 
-  it('should generate a special type for scoped commands', async () => {
+  it('should generate a special type for scoped commands', () => {
     (readFileSync as jest.Mock).mockReturnValue(`// some comment
 
 export function functionExampleScoped(
@@ -257,7 +257,31 @@ declare global {
 `);
   });
 
-  it('should throw descriptive error for object-destructured input', async () => {
+  it('should handle generic types properly', () => {
+    (readFileSync as jest.Mock).mockReturnValue(`// some comment
+
+export function functionExampleGenericType(input1: string) {
+  cy.log<GenericType>('Here is a generic type!');
+}
+`);
+    const result = generateTypesFromAbstractSyntaxTree(filePath, prettierConfig);
+    expect(result).toEqual(`// some comment
+
+export function functionExampleGenericType(input1: string) {
+  cy.log<GenericType>('Here is a generic type!');
+}
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      functionExampleGenericType(input1: string): Chainable;
+    }
+  }
+}
+`);
+  });
+
+  it('should throw descriptive error for object-destructured input', () => {
     (readFileSync as jest.Mock).mockReturnValue(`
 
 export const objectDestructureExample = ({ input1, input2 }: { input1: string; input2: string }) => {


### PR DESCRIPTION
### :pencil: Description
- Fixes an issue where generic types (and probably other TypeScript features) were not being retained properly when run through prettier formatting.
- Thanks to @prc5 for pointing this out!

### :link: Related Issues
- #115
