### PR TITLE
fix: use named import for @babel/generator to fix bundled codegen crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Run cypress-codegen
         run: |
-          bun src/cli.ts --testingType component
-          bun src/cli.ts --testingType e2e
+          bun dist/cli.mjs --testingType component
+          bun dist/cli.mjs --testingType e2e
 
       - name: Check generated types match git
         run: |

--- a/src/generate-content-with-exports.ts
+++ b/src/generate-content-with-exports.ts
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import * as t from "@babel/types";
-import generate from "@babel/generator";
+import { generate } from "@babel/generator";
 import { format, Options } from "prettier";
 import { join, parse, relative } from "path";
 

--- a/src/generate-content-with-imports.ts
+++ b/src/generate-content-with-imports.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
-import generate from "@babel/generator";
+import { generate } from "@babel/generator";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { format, Options } from "prettier";

--- a/src/generate-contents-with-interface.ts
+++ b/src/generate-contents-with-interface.ts
@@ -24,7 +24,7 @@ import type {
   VariableDeclaration,
 } from "@babel/types";
 import * as t from "@babel/types";
-import generate from "@babel/generator";
+import { generate } from "@babel/generator";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { format, Options } from "prettier";


### PR DESCRIPTION
## Summary

- `@babel/generator` exports its `generate` function as both a default and named export. When bundled with rolldown (via `tsdown`), default imports go through an `__toESM` helper with `isNodeMode=1`, which sets `.default` to the entire exports object rather than the actual function — causing `TypeError: (0, import_lib$2.default) is not a function` at runtime.
- Switching all three call sites from a default import to the named `{ generate }` import avoids this code path and resolves the crash.
- The CLI CI job previously ran from TypeScript source via `bun src/cli.ts`, which bypasses the bundler entirely. It has been updated to run from the built `dist/cli.mjs` so bundler regressions like this are caught before release.

## Changes

- Codegen no longer crashes when run from the published npm package
- The CLI CI job now exercises the built artifact rather than the raw TypeScript source

## Test plan

- [ ] `bun run build` completes without errors
- [ ] `bun dist/cli.mjs --testingType e2e` outputs `Codegen complete!`
- [ ] `bun dist/cli.mjs --testingType component` outputs `Codegen complete!`
- [ ] CI `cli` job passes end-to-end

---
Generated with [Claude Code](https://claude.com/claude-code)