### PR TITLE
 fix: resolve prettier config from a file path instead of the cwd directory

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -25,9 +25,9 @@ export const codegen = async (config: Partial<Cypress.PluginConfigOptions>) => {
     nodir: true,
     ignore: indexTsFile,
   });
-  const prettierConfig = (await resolveConfig(process.cwd())) ?? {};
 
   const commandsIndexPath = "cypress/commands/index.ts";
+  const prettierConfig = (await resolveConfig(resolve(commandsIndexPath))) ?? {};
   const exportFileContents = await generateContentWithExports(
     filePaths,
     prettierConfig,

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 Expedia, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it, mock } from "bun:test";
+import { resolve } from "path";
+
+const resolveConfigMock = mock().mockResolvedValue({ singleQuote: true });
+const actualPrettier = await import("prettier");
+mock.module("prettier", () => ({
+  ...actualPrettier,
+  resolveConfig: resolveConfigMock,
+}));
+
+const globSyncMock = mock().mockReturnValue(["cypress/commands/foo.ts"]);
+mock.module("glob", () => ({
+  globSync: globSyncMock,
+}));
+
+const actualFs = await import("fs");
+mock.module("fs", () => ({
+  ...actualFs,
+  readFileSync: mock().mockReturnValue("Cypress.Commands.add('foo', () => {});"),
+  writeFileSync: mock(),
+}));
+
+const { codegen } = await import("../src/codegen");
+
+describe("codegen", () => {
+  it("resolves the prettier config from a file inside the project instead of the cwd directory", async () => {
+    await codegen({ testingType: "e2e" });
+
+    expect(resolveConfigMock).toHaveBeenCalledWith(
+      resolve("cypress/commands/index.ts"),
+    );
+    expect(resolveConfigMock).not.toHaveBeenCalledWith(process.cwd());
+  });
+});


### PR DESCRIPTION
`resolveConfig()` expects a file path, not a directory: it starts its search in that file's parent directory and walks up. Passing `process.cwd()` starts the search one level above the project root, so a project's own `.prettierrc.json` is never found and `codegen()` silently falls back to Prettier's defaults, reformatting generated files on every Cypress launch.

This passes the `cypress/commands/index.ts` path instead, so the search starts inside the project and correctly picks up the project's config.

Added a test asserting `resolveConfig` is called with the resolved file path, not `process.cwd()`.